### PR TITLE
refactor: DM 메시지 첫 전송 시에 채팅방이 실제로 생성되도록 변경

### DIFF
--- a/src/main/java/devut/buzzerbidder/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/devut/buzzerbidder/domain/chat/controller/ChatMessageController.java
@@ -51,10 +51,10 @@ public class ChatMessageController {
         chatMessageService.sendAuctionMessage(auctionId, sender, request);
     }
 
-    // send/chat/dm/{chatRoomId}
-    @MessageMapping("/dm/{chatRoomId}")
+    // send/chat/dm/{itemId}
+    @MessageMapping("/dm/{itemId}")
     public void sendDirectMessage(
-            @DestinationVariable Long chatRoomId,
+            @DestinationVariable Long itemId,
             @Payload ChatMessageRequest request,
             Principal principal
     ) {
@@ -74,6 +74,6 @@ public class ChatMessageController {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        chatMessageService.sendDirectMessage(chatRoomId, sender, request);
+        chatMessageService.sendDirectMessage(itemId, sender, request);
     }
 }

--- a/src/main/java/devut/buzzerbidder/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/devut/buzzerbidder/domain/chat/controller/ChatRoomController.java
@@ -46,19 +46,16 @@ public class ChatRoomController {
         return ApiResponse.ok("채팅방 상세 조회 성공", response);
     }
 
-    @PostMapping("/dm/{delayedItemId}")
-    @Operation(summary = "DM 입장 처리", description = "구매자 <-> 판매자 간 지연 경매품에 대한 DM 채팅방 입장처리를 진행합니다.")
-    public ApiResponse<DirectMessageEnterResponse> enterDirectMessageChatRoom(
+    @GetMapping("/dm/{delayedItemId}")
+    @Operation(summary = "DM 채팅방 조회", description = "상품 ID로 DM 채팅방을 조회합니다. 기존 채팅방이 있으면 메시지 내역을, 없으면 상품 정보만 반환합니다. (채팅방 생성은 첫 메시지 전송 시점)")
+    public ApiResponse<DirectMessageEnterResponse> getDirectMessageChatRoom(
             @PathVariable Long delayedItemId
     ) {
-
         User user = requestContext.getCurrentUser();
 
-        ChatRoom chatRoom = chatRoomService.getOrCreateDMChatRoom(delayedItemId, user);
+        DirectMessageEnterResponse response = chatRoomService.getDmChatRoomByItemId(delayedItemId, user);
 
-        DirectMessageEnterResponse response = new DirectMessageEnterResponse(chatRoom.getId());
-
-        return ApiResponse.ok("구매자와 판매자 DM 채팅방 입장 완료", response);
+        return ApiResponse.ok("DM 채팅방 조회 성공", response);
     }
 
     @PutMapping("/auction/{auctionId}/enter")

--- a/src/main/java/devut/buzzerbidder/domain/chat/dto/response/ChatListResponse.java
+++ b/src/main/java/devut/buzzerbidder/domain/chat/dto/response/ChatListResponse.java
@@ -1,17 +1,36 @@
 package devut.buzzerbidder.domain.chat.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "DM 채팅방 목록 응답")
 public record ChatListResponse(
+        @Schema(description = "채팅방 목록")
         List<ChatRoomItem> chatRooms
 ) {
+    @Schema(description = "채팅방 아이템")
     public record ChatRoomItem(
+            @Schema(description = "채팅방 ID")
             Long chatRoomId,
+
+            @Schema(description = "상품 ID")
+            Long itemId,
+
+            @Schema(description = "상대방 닉네임")
             String otherUserNickname,
+
+            @Schema(description = "상대방 프로필 이미지 URL")
             String otherUserProfileImage,
+
+            @Schema(description = "마지막 메시지 내용")
             String lastMessage,
+
+            @Schema(description = "마지막 메시지 시간")
             LocalDateTime lastMessageTime,
+
+            @Schema(description = "읽지 않은 메시지 존재 여부")
             boolean hasUnreadMessage
     ) {}
 }

--- a/src/main/java/devut/buzzerbidder/domain/chat/dto/response/DirectMessageEnterResponse.java
+++ b/src/main/java/devut/buzzerbidder/domain/chat/dto/response/DirectMessageEnterResponse.java
@@ -1,13 +1,50 @@
 package devut.buzzerbidder.domain.chat.dto.response;
 
+import devut.buzzerbidder.domain.chat.dto.DirectMessageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "DM 채팅 입장 응답")
+import java.util.Collections;
+import java.util.List;
+
+@Schema(description = "DM 채팅방 조회 응답")
 public record DirectMessageEnterResponse(
-        @Schema(description = "입장하려는 채팅방 ID")
-        Long chatRoomId
+        @Schema(description = "기존 채팅방 존재 여부")
+        boolean exists,
+
+        @Schema(description = "채팅방 ID (웹소켓 구독용, 없으면 null)")
+        Long chatRoomId,
+
+        @Schema(description = "상품 정보")
+        ItemInfo itemInfo,
+
+        @Schema(description = "메시지 목록 (기존 채팅방이 있을 경우)")
+        List<DirectMessageDto> messages
 ) {
-    public DirectMessageEnterResponse(Long chatRoomId) {
-        this.chatRoomId = chatRoomId;
+    @Schema(description = "상품 정보")
+    public record ItemInfo(
+            @Schema(description = "상품 ID")
+            Long itemId,
+
+            @Schema(description = "상품명")
+            String itemName,
+
+            @Schema(description = "현재 가격")
+            Long currentPrice,
+
+            @Schema(description = "상품 이미지 URL")
+            String itemImageUrl,
+
+            @Schema(description = "경매 상태")
+            String auctionStatus
+    ) {}
+
+    // 채팅방이 없을 때
+    public static DirectMessageEnterResponse notExists(ItemInfo itemInfo) {
+        return new DirectMessageEnterResponse(false, null, itemInfo, Collections.emptyList());
+    }
+
+    // 채팅방이 있을 때
+    public static DirectMessageEnterResponse exists(Long chatRoomId, ItemInfo itemInfo, List<DirectMessageDto> messages) {
+        return new DirectMessageEnterResponse(true, chatRoomId, itemInfo, messages);
     }
 }

--- a/src/main/java/devut/buzzerbidder/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/devut/buzzerbidder/domain/chat/service/ChatMessageService.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 public class ChatMessageService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomService chatRoomService;
     private final SimpMessagingTemplate messagingTemplate;
 
     // 경매방 채팅 브로드캐스트 경로
@@ -63,15 +64,9 @@ public class ChatMessageService {
     }
 
     @Transactional
-    public void sendDirectMessage(Long chatRoomId, User sender, ChatMessageRequest request) {
-        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
-
-        // 해당 채팅방의 참여자가 아닐 시 예외처리
-        boolean isParticipant = chatRoomEnteredRepository.existsByUserAndChatRoom(sender, chatRoom);
-        if (!isParticipant) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
-        }
+    public void sendDirectMessage(Long itemId, User sender, ChatMessageRequest request) {
+        // itemId로 채팅방 조회 또는 생성
+        ChatRoom chatRoom = chatRoomService.getOrCreateDMChatRoom(itemId, sender);
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoom(chatRoom)
@@ -82,7 +77,7 @@ public class ChatMessageService {
 
         // 채팅방 정보 업데이트
         chatRoomRepository.updateLastMessage(
-                chatRoomId,
+                chatRoom.getId(),
                 chatMessage.getId(),
                 chatMessage.getMessage(),
                 chatMessage.getCreateDate()
@@ -102,7 +97,7 @@ public class ChatMessageService {
                 chatMessage.getCreateDate()
         );
 
-        String destination = DM_DESTINATION_PREFIX + chatRoomId;
+        String destination = DM_DESTINATION_PREFIX + chatRoom.getId();
         messagingTemplate.convertAndSend(destination, response);
     }
 }

--- a/src/main/java/devut/buzzerbidder/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/devut/buzzerbidder/domain/chat/service/ChatRoomService.java
@@ -5,13 +5,13 @@ import devut.buzzerbidder.domain.auctionroom.repository.AuctionRoomRepository;
 import devut.buzzerbidder.domain.chat.dto.DirectMessageDto;
 import devut.buzzerbidder.domain.chat.dto.response.ChatListResponse;
 import devut.buzzerbidder.domain.chat.dto.response.ChatRoomDetailResponse;
+import devut.buzzerbidder.domain.chat.dto.response.DirectMessageEnterResponse;
 import devut.buzzerbidder.domain.chat.entity.ChatMessage;
 import devut.buzzerbidder.domain.chat.entity.ChatRoom;
 import devut.buzzerbidder.domain.chat.entity.ChatRoomEntered;
 import devut.buzzerbidder.domain.chat.repository.ChatRoomRepository;
 import devut.buzzerbidder.domain.chat.repository.ChatRoomEnteredRepository;import devut.buzzerbidder.domain.user.dto.response.UserInfo;
 import devut.buzzerbidder.domain.chat.repository.ChatMessageRepository;
-import devut.buzzerbidder.domain.chat.repository.ChatRoomEnteredRepository;
 import devut.buzzerbidder.domain.delayeditem.entity.DelayedItem;
 import devut.buzzerbidder.domain.delayeditem.repository.DelayedItemRepository;
 import devut.buzzerbidder.domain.user.entity.User;
@@ -167,7 +167,6 @@ public class ChatRoomService {
                 .collect(Collectors.toList());
     }
 
-    // TODO: 1대1 채팅 inActive 활용
     public void validateAuctionRoomEntry(Long auctionId) {
         AuctionRoom auctionRoom = auctionRoomRepository.findById(auctionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUCTION_ROOM_NOT_FOUND));
@@ -211,6 +210,7 @@ public class ChatRoomService {
 
                     return new ChatListResponse.ChatRoomItem(
                             room.getId(),
+                            room.getReferenceEntityId(),
                             otherUser.getNickname(),
                             otherUser.getProfileImageUrl(),
                             room.getLastMessageContent(),
@@ -262,6 +262,65 @@ public class ChatRoomService {
                 )).toList();
 
         return new ChatRoomDetailResponse(itemInfo, messageResponses);
+    }
+
+    /**
+     * itemId로 DM 채팅방 조회
+     * - 채팅방이 있으면: 상품 정보 + 메시지 목록 반환
+     * - 채팅방이 없으면: 상품 정보만 반환
+     */
+    @Transactional
+    public DirectMessageEnterResponse getDmChatRoomByItemId(Long itemId, User user) {
+        DelayedItem item = delayedItemRepository.findDelayedItemWithImagesById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_DATA));
+
+        // 판매자가 자신의 물건에 채팅 시도 시 예외처리
+        if (user.getId().equals(item.getSellerUserId())) {
+            throw new BusinessException(ErrorCode.SELF_CHAT_NOT_ALLOWED);
+        }
+
+        String firstImageUrl = item.getImages().isEmpty() ? null : item.getImages().getFirst().getImageUrl();
+
+        DirectMessageEnterResponse.ItemInfo itemInfo = new DirectMessageEnterResponse.ItemInfo(
+                item.getId(),
+                item.getName(),
+                item.getCurrentPrice(),
+                firstImageUrl,
+                item.getAuctionStatus().name()
+        );
+
+        // 기존 채팅방 조회
+        Optional<ChatRoom> existingRoom = chatRoomRepository.findDmRoomByItemAndUser(itemId, user.getId());
+
+        if (existingRoom.isEmpty()) {
+            // 채팅방이 없으면 상품 정보만 반환
+            return DirectMessageEnterResponse.notExists(itemInfo);
+        }
+
+        ChatRoom chatRoom = existingRoom.get();
+
+        // 채팅방 조회 시 읽음 상태 업데이트
+        chatRoomEnteredRepository.findByUserAndChatRoom(user, chatRoom)
+                .ifPresent(entry -> {
+                    if (chatRoom.getLastMessageId() != null) {
+                        entry.updateReadStatus(chatRoom.getLastMessageId());
+                    }
+                });
+
+        // 메시지 내역 조회
+        List<ChatMessage> chatMessages = chatMessageRepository.findByChatRoomOrderByCreateDateAsc(chatRoom);
+
+        List<DirectMessageDto> messageResponses = chatMessages.stream()
+                .map(m -> new DirectMessageDto(
+                        m.getId(),
+                        m.getSender().getId(),
+                        m.getSender().getProfileImageUrl(),
+                        m.getSender().getNickname(),
+                        m.getMessage(),
+                        m.getCreateDate()
+                )).toList();
+
+        return DirectMessageEnterResponse.exists(chatRoom.getId(), itemInfo, messageResponses);
     }
 }
 


### PR DESCRIPTION
## 📎 Issue #163 <!-- 이슈 번호를 적어주세요 -->
<!-- closed #163  -->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
DM 메시지 첫 전송 시에 채팅방이 실제로 생성되도록 변경

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
기존 입장 처리 api에서 채팅방 조회로 변경
채팅방 존재 여부에 따라 분기 처리 진행
- exists=true: 기존 채팅방 ID, 상품 정보, 메시지 목록 반환
- exists=false: 상품 정보만 반환 (채팅방은 미생성)

이 후 첫 메시지 전송 시 getOrCreateDMChatRoom 호출하여 채팅방 조회 또는 생성

## ✅ 체크리스트 <!-- 체크 리스트를 작성해서 본인이 확인해보고 추가로 팀원이 리뷰할 때 확인 했으면 하는 부분 작성해주세요 -->

- [ ] 예외 처리 충분히 고려함
- [x] 코드 오류가 없음
- [x] 이슈 연결
- [ ] 추가로 팀원이 리뷰 해줬으면 하는 부분 이곳에 작성
