### PR TITLE
feat: 알림 자동 만료 기능 추가

### DIFF
--- a/src/main/java/devut/buzzerbidder/domain/notification/enums/NotificationTTL.java
+++ b/src/main/java/devut/buzzerbidder/domain/notification/enums/NotificationTTL.java
@@ -1,0 +1,43 @@
+package devut.buzzerbidder.domain.notification.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 알림 타입별 보관 기간(TTL) 전략
+ */
+@Getter
+@RequiredArgsConstructor
+public enum NotificationTTL {
+    /**
+     * 일반 알림
+     * - 읽은 알림: 30일 (고객이 확인한 정보는 단기 보관)
+     * - 읽지 않은 알림: 90일 (미확인 알림은 충분히 대기)
+     */
+    NORMAL(30, 90),
+
+    /**
+     * 거래/법적 증빙성 알림
+     * - 읽음/안 읽음 무관하게 365일 보관
+     * - 낙찰, 결제 완료, 거래 취소 등
+     * - CS 대응, 분쟁 해결, 감사 목적
+     */
+    LEGAL(365, 365),
+
+    /**
+     * 시스템/정책 알림
+     * - 보안, 약관 변경, 서비스 점검 등
+     * - 읽음/안 읽음 무관하게 180일 보관
+     */
+    SYSTEM(180, 180);
+
+    /**
+     * 읽은 알림 보관 기간 (일)
+     */
+    private final int readRetentionDays;
+
+    /**
+     * 읽지 않은 알림 보관 기간 (일)
+     */
+    private final int unreadRetentionDays;
+}

--- a/src/main/java/devut/buzzerbidder/domain/notification/enums/NotificationType.java
+++ b/src/main/java/devut/buzzerbidder/domain/notification/enums/NotificationType.java
@@ -1,22 +1,46 @@
 package devut.buzzerbidder.domain.notification.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum NotificationType {
-    DELAYED_FIRST_BID,              // 지연 경매 첫 입찰 알림
-    DELAYED_BID_OUTBID,             // 지연 경매 내 입찰가가 밀림
-    DELAYED_SUCCESS_BIDDER,         // 지연 경매 입찰자에게 낙찰 알림
-    DELAYED_SUCCESS_SELLER,         // 지연 경매 판매자에게 낙찰 알림
-    DELAYED_FAILED_SELLER,          // 지연 경매 판매자에게 유찰 알림
-    DELAYED_BUY_NOW_SOLD,           // 지연 경매 판매자에게 즉시 구매 알림
-    DELAYED_CANCELLED_BY_BUY_NOW,   // 지연 경매 이전 최고 입찰자에게 즉시 구매로 인한 취소 알림
-    DM_FIRST_MESSAGE,               // 지연 상품 첫 DM 알림
-    LIVE_AUCTION_START,             // 찜한 상품 라이브 경매 시작
-    LIVE_SUCCESS_BIDDER,            // 라이브 경매 낙찰자에게 낙찰 알림
-    LIVE_SUCCESS_SELLER,            // 라이브 경매 판매자에게 낙찰 알림
-    LIVE_FAILED_SELLER,             // 라이브 경매 판매자에게 유찰 알림
-    PAYMENT_REMINDER,               // 잔금 리마인더 알림
-    PAYMENT_TIMEOUT_BUYER,          // 잔금 결제 기한 초과로 구매자에게 거래 취소 알림
-    PAYMENT_TIMEOUT_SELLER,         // 잔금 결제 미완료로 판매자에게 거래 취소 알림
-    PAYMENT_COMPLETE,               // 잔금 결제 완료
-    ITEM_SHIPPED,                   // 상품 배송 시작
-    TRANSACTION_COMPLETE,           // 거래 완료
+    // 일반 알림 (읽음: 30일, 안 읽음: 90일)
+    DELAYED_FIRST_BID(NotificationTTL.NORMAL),              // 지연 경매 첫 입찰 알림
+    DELAYED_BID_OUTBID(NotificationTTL.NORMAL),             // 지연 경매 내 입찰가가 밀림
+    DELAYED_FAILED_SELLER(NotificationTTL.NORMAL),          // 지연 경매 판매자에게 유찰 알림
+    DELAYED_BUY_NOW_SOLD(NotificationTTL.NORMAL),           // 지연 경매 판매자에게 즉시 구매 알림
+    DELAYED_CANCELLED_BY_BUY_NOW(NotificationTTL.NORMAL),   // 지연 경매 이전 최고 입찰자에게 즉시 구매로 인한 취소 알림
+    DM_FIRST_MESSAGE(NotificationTTL.NORMAL),               // 지연 상품 첫 DM 알림
+    LIVE_AUCTION_START(NotificationTTL.NORMAL),             // 찜한 상품 라이브 경매 시작
+    LIVE_FAILED_SELLER(NotificationTTL.NORMAL),             // 라이브 경매 판매자에게 유찰 알림
+    PAYMENT_REMINDER(NotificationTTL.NORMAL),               // 잔금 리마인더 알림
+    ITEM_SHIPPED(NotificationTTL.NORMAL),                   // 상품 배송 시작
+
+    // 거래/법적 증빙성 알림 (읽음: 365일, 안 읽음: 365일)
+    DELAYED_SUCCESS_BIDDER(NotificationTTL.LEGAL),         // 지연 경매 입찰자에게 낙찰 알림
+    DELAYED_SUCCESS_SELLER(NotificationTTL.LEGAL),         // 지연 경매 판매자에게 낙찰 알림
+    LIVE_SUCCESS_BIDDER(NotificationTTL.LEGAL),            // 라이브 경매 낙찰자에게 낙찰 알림
+    LIVE_SUCCESS_SELLER(NotificationTTL.LEGAL),            // 라이브 경매 판매자에게 낙찰 알림
+    PAYMENT_TIMEOUT_BUYER(NotificationTTL.LEGAL),          // 잔금 결제 기한 초과로 구매자에게 거래 취소 알림
+    PAYMENT_TIMEOUT_SELLER(NotificationTTL.LEGAL),         // 잔금 결제 미완료로 판매자에게 거래 취소 알림
+    PAYMENT_COMPLETE(NotificationTTL.LEGAL),               // 잔금 결제 완료
+    TRANSACTION_COMPLETE(NotificationTTL.LEGAL);           // 거래 완료
+
+    private final NotificationTTL ttl;
+
+    /**
+     * 읽은 알림 보관 기간 (일)
+     */
+    public int getReadRetentionDays() {
+        return ttl.getReadRetentionDays();
+    }
+
+    /**
+     * 읽지 않은 알림 보관 기간 (일)
+     */
+    public int getUnreadRetentionDays() {
+        return ttl.getUnreadRetentionDays();
+    }
 }

--- a/src/main/java/devut/buzzerbidder/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/devut/buzzerbidder/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package devut.buzzerbidder.domain.notification.repository;
 
 import devut.buzzerbidder.domain.notification.entity.Notification;
 import devut.buzzerbidder.domain.notification.enums.NotificationType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -30,6 +31,22 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         @Param("type") NotificationType type,
         @Param("resourceId") Long resourceId,
         @Param("keyword") String keyword
+    );
+
+    /**
+     * TTL 기반 알림 삭제 (타입별 보관 기간 적용)
+     * 읽은 알림: type별 readRetentionDays 기준
+     * 안 읽은 알림: type별 unreadRetentionDays 기준
+     */
+    @Modifying
+    @Query("DELETE FROM Notification n " +
+           "WHERE n.type = :type " +
+           "AND ((n.isChecked = true AND n.createDate < :readThreshold) " +
+           "OR (n.isChecked = false AND n.createDate < :unreadThreshold))")
+    int deleteExpiredNotificationsByType(
+        @Param("type") NotificationType type,
+        @Param("readThreshold") LocalDateTime readThreshold,
+        @Param("unreadThreshold") LocalDateTime unreadThreshold
     );
 
 }

--- a/src/main/java/devut/buzzerbidder/domain/notification/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/devut/buzzerbidder/domain/notification/scheduler/NotificationCleanupScheduler.java
@@ -1,0 +1,67 @@
+package devut.buzzerbidder.domain.notification.scheduler;
+
+import devut.buzzerbidder.domain.notification.enums.NotificationType;
+import devut.buzzerbidder.domain.notification.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 알림 자동 만료 스케줄러
+ * - 매일 새벽 3시에 실행
+ * - 타입별 TTL 정책에 따라 만료된 알림 삭제
+ * - 일반 알림: 읽음 30일 / 안 읽음 90일
+ * - 법적 증빙 알림: 365일
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationCleanupScheduler {
+
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * 알림 자동 만료 처리
+     * - Cron: 매일 새벽 3시 실행
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupExpiredNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 모든 알림 타입에 대해 TTL 정책 적용
+        for (NotificationType type : NotificationType.values()) {
+            try {
+                int deleted = cleanupByType(type, now);
+
+                if (deleted > 0) {
+                    log.info("알림 삭제 완료: type={}, count={}, readRetention={}일, unreadRetention={}일",
+                        type,
+                        deleted,
+                        type.getReadRetentionDays(),
+                        type.getUnreadRetentionDays()
+                    );
+                }
+            } catch (Exception e) {
+                log.error("알림 삭제 실패: type={}", type, e);
+            }
+        }
+    }
+
+    /**
+     * 타입별 만료 알림 삭제
+     */
+    private int cleanupByType(NotificationType type, LocalDateTime now) {
+        LocalDateTime readThreshold = now.minusDays(type.getReadRetentionDays());
+        LocalDateTime unreadThreshold = now.minusDays(type.getUnreadRetentionDays());
+
+        return notificationRepository.deleteExpiredNotificationsByType(
+            type,
+            readThreshold,
+            unreadThreshold
+        );
+    }
+}


### PR DESCRIPTION
## 📎 Issue 번호<!-- 이슈 번호를 적어주세요 -->
#231

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

알림 시스템에 TTL(Time To Live) 기반 자동 만료 정책을 추가
  - 일반 알림: 읽음 30일, 안 읽음 90일 후 자동 삭제
  - 거래/법적 증빙 알림: 읽음/안 읽음 모두 365일 보관 후 삭제
  - 매일 새벽 3시 자동 실행 (Spring Scheduler)

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

알림 타입별 보관 기간 정책 정의
스케줄러 구현

## ✅ 체크리스트 <!-- 체크 리스트를 작성해서 본인이 확인해보고 추가로 팀원이 리뷰할 때 확인 했으면 하는 부분 작성해주세요 -->

- [ ] 예외 처리 충분히 고려함
- [x] 코드 오류가 없음
- [x] 이슈 연결
- [ ] 추가로 팀원이 리뷰 해줬으면 하는 부분 이곳에 작성
